### PR TITLE
Except for windows, the env variable should be PATH and not path

### DIFF
--- a/fork.js
+++ b/fork.js
@@ -34,7 +34,9 @@ function fork(jsPath, args, options) {
 
 function nodeJSPath() {
   return new Promise((resolve, reject) => {
-    const paths = process.env.path.split(process.platform === 'win32' ? ';' : ':');
+    const pathEnvName = process.platform === 'win32' ? 'path' : 'PATH';
+    const pathEnvSeparator = process.platform === 'win32' ? ';' : ':';
+    const paths = process.env[pathEnvName].split(pathEnvSeparator);
 
     const searchPaths = [].concat(
       paths.map(p => path.resolve(p, 'node')),

--- a/worker/findtests.js
+++ b/worker/findtests.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const
-  Glob = require('Glob').Glob,
+  Glob = require('glob').Glob,
   Mocha = require('mocha'),
   path = require('path'),
   Promise = require('bluebird'),


### PR DESCRIPTION
# What does this PR do:

Changes the way the `fork.js` detects the Node.js path, to use the right _env_ property depending on the OS (windows or not).

Also, changes the name of the glob's require from 'Glob' to 'glob' on the `worker/findtests.js`, as described by @shybyte on PR #6 .
# Where should the reviewer start:
- Diffs.

In my case, I used `proxyquire` and stubbed the `vscode` package in order to run a specific test on the `fork.js`. It is quite impractical to write tests to extensions, since the `vscode` is not a _real_ npm package .
😄 

Possibly fixing issues: #3 and #5 
